### PR TITLE
Expand driver tests

### DIFF
--- a/tests/test_all_nodes.py
+++ b/tests/test_all_nodes.py
@@ -91,6 +91,24 @@ def main() -> None:
     radio_pub.publish(roslibpy.Message({"data": "ping"}))
     radio_pub.unadvertise()
 
+    # Exercise services from each node
+    svc_specs = [
+        ("/clear_counts", "std_srvs/srv/Trigger", {}),
+        ("/request_last", "std_srvs/srv/Trigger", {}),
+        ("/pmtk_cmd", "ros2_ddboat/srv/PmtkCmd", {"command": "PMTK605"}),
+        ("/fast_heading_calibration", "std_srvs/srv/Trigger", {}),
+        ("/set_standby", "std_srvs/srv/SetBool", {"data": False}),
+        ("/get_config", "std_srvs/srv/Trigger", {}),
+        ("/calibrate_esc", "std_srvs/srv/Trigger", {}),
+    ]
+    for name, srv_type, payload in svc_specs:
+        try:
+            srv = roslibpy.Service(client, name, srv_type)
+            res = srv.call(roslibpy.ServiceRequest(payload), timeout=5)
+            print(f"{name}: {res}")
+        except Exception as e:
+            print(f"{name} failed: {e}")
+
     # ----------------------------------------------------------------------
     # Wait
     # ----------------------------------------------------------------------

--- a/tests/test_arduino_node.py
+++ b/tests/test_arduino_node.py
@@ -34,11 +34,32 @@ def main() -> None:
         twist_topic.publish(roslibpy.Message(twist_msg))
         time.sleep(0.1)
 
+
+    # Exercise all available services
+    services = [
+        'calibrate_esc',
+        'get_cmd_motor',
+        'get_cmd_motor_esc',
+        'get_rc_chan',
+        'get_raw_rc_chan',
+        'get_status',
+        'get_energy_saver',
+    ]
+
+    for name in services:
+        srv = roslibpy.Service(client, f'/{name}', 'std_srvs/srv/Trigger')
+        try:
+            res = srv.call(roslibpy.ServiceRequest(), timeout=5)
+            print(f'{name}: success={res["success"]} msg={res.get("message", "")}')
+        except Exception as e:
+            print(f'{name} call failed: {e}')
+
     # Clean up from a separate thread
     def _shutdown():
         print('Shutting down: unadvertising and terminating client')
         twist_topic.unadvertise()
         client.terminate()
+
     threading.Thread(target=_shutdown, daemon=True).start()
 
 

--- a/tests/test_encoders_node.py
+++ b/tests/test_encoders_node.py
@@ -23,10 +23,25 @@ def main() -> None:
     def on_encoders(msg):
         data = msg['data']
         print(f'encoders: {data}')
+        # Exercise services once the first message arrives
+        clear_srv = roslibpy.Service(client, '/clear_counts', 'std_srvs/srv/Trigger')
+        last_srv = roslibpy.Service(client, '/request_last', 'std_srvs/srv/Trigger')
+        try:
+            res = clear_srv.call(roslibpy.ServiceRequest(), timeout=5)
+            print(f'clear_counts: {res}')
+        except Exception as e:
+            print(f'clear_counts failed: {e}')
+        try:
+            res = last_srv.call(roslibpy.ServiceRequest(), timeout=5)
+            print(f'request_last: {res}')
+        except Exception as e:
+            print(f'request_last failed: {e}')
+
         # Clean up in a background thread
         def _shutdown():
             enc_topic.unsubscribe()
             client.terminate()
+
         threading.Thread(target=_shutdown, daemon=True).start()
 
     enc_topic = roslibpy.Topic(

--- a/tests/test_gps_node.py
+++ b/tests/test_gps_node.py
@@ -24,6 +24,16 @@ def main() -> None:
         lat = msg['latitude']
         lon = msg['longitude']
         print(f"Received fix: {lat:.6f}, {lon:.6f}")
+
+        # Try a PMTK command service call
+        pmtk_srv = roslibpy.Service(client, '/pmtk_cmd', 'ros2_ddboat/srv/PmtkCmd')
+        req = roslibpy.ServiceRequest({'command': 'PMTK605'})  # query firmware ver
+        try:
+            res = pmtk_srv.call(req, timeout=5)
+            print(f'pmtk_cmd response: {res.get("response", "")}')
+        except Exception as e:
+            print(f'pmtk_cmd failed: {e}')
+
         # Clean up in a background thread to avoid joining the current thread
         def _shutdown():
             fix_topic.unsubscribe()

--- a/tests/test_imu_node.py
+++ b/tests/test_imu_node.py
@@ -22,10 +22,19 @@ def main() -> None:
 
     def on_imu(msg):
         print(f"IMU msg received: {msg}")
+
+        calib_srv = roslibpy.Service(client, '/fast_heading_calibration', 'std_srvs/srv/Trigger')
+        try:
+            res = calib_srv.call(roslibpy.ServiceRequest(), timeout=5)
+            print(f'fast_heading_calibration: {res}')
+        except Exception as e:
+            print(f'fast_heading_calibration failed: {e}')
+
         # Clean up in a background thread
         def _shutdown():
             imu_topic.unsubscribe()
             client.terminate()
+
         threading.Thread(target=_shutdown, daemon=True).start()
 
     imu_topic = roslibpy.Topic(

--- a/tests/test_radio_node.py
+++ b/tests/test_radio_node.py
@@ -39,9 +39,12 @@ def main() -> None:
     rx_topic = roslibpy.Topic(client, '/radio_rx', 'std_msgs/String')
     rx_topic.subscribe(on_rx)
 
-    # Publish a test message
-    tx_msg = {'data': 'ping'}
-    tx_topic.publish(roslibpy.Message(tx_msg))
+    # Publish a few test messages like the original driver did
+    for i in range(3):
+        tx_msg = {'data': f'ping {i+1}'}
+        print(f'sending: {tx_msg["data"]}')
+        tx_topic.publish(roslibpy.Message(tx_msg))
+        time.sleep(0.1)
 
     # Keep the script alive until the callback terminates the client
     try:

--- a/tests/test_temp_node.py
+++ b/tests/test_temp_node.py
@@ -28,6 +28,18 @@ def main() -> None:
         temp = msg['temperature']
         print(f"Received temp {received['count']}: {temp}")
         if received['count'] >= 2:
+            standby_srv = roslibpy.Service(client, '/set_standby', 'std_srvs/srv/SetBool')
+            cfg_srv = roslibpy.Service(client, '/get_config', 'std_srvs/srv/Trigger')
+            try:
+                res = standby_srv.call(roslibpy.ServiceRequest({'data': True}), timeout=5)
+                print(f'set_standby(True): {res}')
+                res = cfg_srv.call(roslibpy.ServiceRequest(), timeout=5)
+                print(f'get_config: {res}')
+                res = standby_srv.call(roslibpy.ServiceRequest({'data': False}), timeout=5)
+                print(f'set_standby(False): {res}')
+            except Exception as e:
+                print(f'standby/config service failed: {e}')
+
             # Clean up in a background thread to avoid joining current thread
             def _shutdown():
                 left_topic.unsubscribe()


### PR DESCRIPTION
## Summary
- expand arduino driver test to invoke available services
- call encoders and gps services from their tests
- test IMU calibration and temperature node services
- publish multiple LoRa packets in the radio test
- run all services in the test that exercises every node

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865d49127ac832896b2db77b19ee497