### PR TITLE
Improve docker-compose and rosbridge docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,54 @@ Replace `test_gps_node.py` with any other script to exercise a different node.
 * Use `docker exec -it <container> bash` to enter a running boat and introspect
   topics with `ros2 topic echo …`.
 
+---
+
+## Using docker-compose
+
+The repository ships with a `docker-compose.yml` that orchestrates the driver
+containers and the optional WebSocket bridge.  Two profiles are provided:
+
+* **`hw`** – run against the real Raspberry Pi hardware.
+* **`sim`** – full software emulation for development on a laptop.
+
+Run all drivers together with:
+
+```bash
+docker compose --profile hw up            # real hardware
+# or
+docker compose --profile sim up           # simulated devices
+```
+
+When using the *hardware* profile you can override which host devices are bound
+into the containers by exporting environment variables before starting compose
+(e.g. `GPS_DEV`, `ARDUINO_DEV`, … as documented in the compose file).
+
+The `rosbridge` service (enabled in both profiles) exposes the ROS 2 graph on a
+WebSocket port so that external applications can interact with the boat without
+running ROS 2 natively.
+
+---
+
+## Talking to the boat with `roslibpy`
+
+`roslibpy` is a small Python library that speaks the rosbridge protocol.  After
+`docker compose` has started the `rosbridge` service you can publish and
+subscribe to topics from anywhere on the network:
+
+```python
+import roslibpy
+
+client = roslibpy.Ros(host='localhost', port=9090)
+client.run()
+
+twist_pub = roslibpy.Topic(client, '/motors_cmd', 'geometry_msgs/Twist')
+twist_pub.publish(roslibpy.Message({'linear': {'x': 50.0, 'y': 50.0, 'z': 0.0},
+                                    'angular': {'x': 0.0, 'y': 0.0, 'z': 0.0}}))
+twist_pub.unadvertise()
+
+client.terminate()
+```
+
+The scripts under `tests/` provide more complete examples that exercise all
+drivers via rosbridge.
+


### PR DESCRIPTION
## Summary
- document the docker-compose setup for hardware and simulation
- explain how to connect via rosbridge using roslibpy

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865eeb86c8c8328a35a613f3785c743