### PR TITLE
Fix Python locale for armhf container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
 FROM quillianne/ros2
 
-ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PYTHONIOENCODING=UTF-8
+
 WORKDIR /opt/ws
 
 
 # Build tools for any native libs your packages need
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        locales && \
+    locale-gen en_US.UTF-8 && \
     rm -rf /var/lib/apt/lists/*
 
 ENV MAKEFLAGS="-j1"


### PR DESCRIPTION
## Summary
- ensure UTF-8 locale inside Docker image
- install locales package and generate locale
- set `PYTHONIOENCODING` to avoid Python codec errors

## Testing
- `python3 -m compileall -q tests`

------
https://chatgpt.com/codex/tasks/task_e_68693da8593083288adfe97f9a755d23