### PR TITLE
Improve rosbridge configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ into the containers by exporting environment variables before starting compose
 
 The `rosbridge` service (enabled in both profiles) exposes the ROS 2 graph on a
 WebSocket port so that external applications can interact with the boat without
-running ROS 2 natively.
+running ROS 2 natively.  It is configured to use a 5 s default timeout for
+service calls and to handle service and action requests in background threads so
+that the WebSocket loop never blocks.
 
 You may need to pull new changes in the container image by doing:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,5 +143,4 @@ services:
                  -p default_call_service_timeout:=5.0 \
                  -p call_services_in_new_thread:=true \
                  -p send_action_goals_in_new_thread:=true'
-    depends_on:
-      - ddboat_sim    profiles: ["sim", "hw"]
+    depends_on: [ddboat_sim]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,11 +137,11 @@ services:
     image: "${IMAGE:-quillianne/ddboat}"
     network_mode: host
     command: >
-      bash -c "source /opt/ros/humble/setup.bash && \
-               ros2 launch rosbridge_server rosbridge_websocket_launch.xml \
-               default_call_service_timeout:=5.0 \
-               call_services_in_new_thread:=true \
-               send_action_goals_in_new_thread:=true"
+      bash -c 'source /opt/ros/humble/setup.bash && \
+               ros2 run rosbridge_server rosbridge_websocket \
+                 --ros-args \
+                 -p default_call_service_timeout:=5.0 \
+                 -p call_services_in_new_thread:=true \
+                 -p send_action_goals_in_new_thread:=true'
     depends_on:
-      - ddboat_sim
-    profiles: ["sim", "hw"]
+      - ddboat_sim    profiles: ["sim", "hw"]


### PR DESCRIPTION
## Summary
- set rosbridge parameters using `ros2 run` and `--ros-args`
- document rosbridge defaults in README

## Testing
- `pip install roslibpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686db195a25c832880a6437aaafa9e51