### PR TITLE
Configure ports via dotenv

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,9 @@
 IMAGE=quillianne/ddboat
 # Docker image for base ROS 2 Humble
 ROS2_IMAGE=quillianne/ros2
+
+# Serial devices on the host.  Adjust if your /dev numbers differ.
+GPS_DEV=/dev/ttyGPS0
+ARDUINO_DEV=/dev/ttyV0
+ENC_DEV=/dev/ttyENC0
+LORA_DEV=/dev/ttyLORA1

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ git clone https://github.com/Quillianne/drivers-ddboat-ros2
 cd drivers-ddboat-ros2
 sudo usermod -aG docker $USER
 newgrp docker  # apply group change without logout (optional)
+
+# Enable the I2C interface so the IMU and temperature sensors work:
+sudo raspi-config  # Interface Options -> I2C -> Enable and reboot
 ```
 
 you can then either build the DDBOAT Docker image or pull it.
@@ -89,6 +92,19 @@ your own registry:
 IMAGE=quillianne/ddboat
 ROS2_IMAGE=quillianne/ros2
 ```
+
+## Configure device ports
+
+Edit `.env` if the serial device numbers on your Raspberry Pi differ from the defaults:
+
+```bash
+GPS_DEV=/dev/ttyGPS0
+ARDUINO_DEV=/dev/ttyV0
+ENC_DEV=/dev/ttyENC0
+LORA_DEV=/dev/ttyLORA1
+```
+
+These variables are used by `docker-compose.yml` to bind the correct host devices.
 
 ---
 
@@ -112,9 +128,9 @@ docker compose --profile sim up -d          # simulated devices
 
 -d option is falcultative but useful for running in detached mode and allowing auto restart of docker containers on start up
 
-When using the *hardware* profile you can override which host devices are bound
-into the containers by exporting environment variables before starting compose
-(e.g. `GPS_DEV`, `ARDUINO_DEV`, … as documented in the compose file).
+When using the *hardware* profile you can change which host devices are bound
+into the containers by editing `.env` before starting compose
+(see the `GPS_DEV`, `ARDUINO_DEV`, … variables documented in the compose file).
 
 The `rosbridge` service (enabled in both profiles) exposes the ROS 2 graph on a
 WebSocket port so that external applications can interact with the boat without

--- a/README.md
+++ b/README.md
@@ -146,6 +146,19 @@ docker compose --profile hw pull            # real hardware
 docker compose --profile sim pull           # simulated devices
 ```
 
+### Managing the compose stack
+
+Use the same `--profile` flag with all commands to target either the hardware
+or simulation services:
+
+```bash
+docker compose --profile hw stop         # pause running containers
+docker compose --profile hw start        # resume stopped containers
+docker compose --profile hw down         # remove containers
+docker compose --profile hw logs -f      # view aggregated logs
+```
+
+
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,13 +18,12 @@
 #   ddboat_sim – device emulator + all drivers
 #
 # === Selecting the host serial ports ===
-# Export these variables *before* running `docker compose` to bind to the
-# correct device numbers on your Pi/PC:
-#
-#   export GPS_DEV=/dev/ttyGPS2      # defaults to /dev/ttyGPS0
-#   export ARDUINO_DEV=/dev/ttyV3    # defaults to /dev/ttyV0
-#   export ENC_DEV=/dev/ttyENC1      # defaults to /dev/ttyENC0
-#   export LORA_DEV=/dev/ttyLORA5    # defaults to /dev/ttyLORA1
+# Set the device paths in `.env` to match the numbers on your Pi/PC.
+# Example values (the defaults) are:
+#   GPS_DEV=/dev/ttyGPS0
+#   ARDUINO_DEV=/dev/ttyV0
+#   ENC_DEV=/dev/ttyENC0
+#   LORA_DEV=/dev/ttyLORA1
 #
 # Inside every container the devices are always visible at:
 #   /dev/ttyGPS0   /dev/ttyV0   /dev/ttyENC0   /dev/ttyLORA1


### PR DESCRIPTION
## Summary
- configure device port mappings from `.env`
- document enabling i2c in Raspberry Pi onboarding section
- explain how to edit `.env` for device names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dbe4f180c8328a2182bedb89313d8