### PR TITLE
Update compose profiles and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,17 +113,18 @@ These variables are used by `docker-compose.yml` to bind the correct host device
 ## Using docker-compose
 
 The repository ships with a `docker-compose.yml` that orchestrates the driver
-containers and the optional WebSocket bridge.  Two profiles are provided:
+containers and the optional WebSocket bridge.  Three profiles are provided:
 
-* **`hw`** – run against the real Raspberry Pi hardware.
+* **`hw`** – run all drivers in a single container on real hardware.
 * **`sim`** – full software emulation for development on a laptop.
+* **`hw_extra`** – launch individual driver containers for debugging.
 
 Run all drivers together with:
 
 ```bash
-docker compose --profile hw up -d           # real hardware
+docker compose --profile hw up -d           # ddboat_all + rosbridge
 # or
-docker compose --profile sim up -d          # simulated devices
+docker compose --profile sim up -d          # ddboat_sim + rosbridge
 ```
 
 -d option is falcultative but useful for running in detached mode and allowing auto restart of docker containers on start up
@@ -132,7 +133,7 @@ When using the *hardware* profile you can change which host devices are bound
 into the containers by editing `.env` before starting compose
 (see the `GPS_DEV`, `ARDUINO_DEV`, … variables documented in the compose file).
 
-The `rosbridge` service (enabled in both profiles) exposes the ROS 2 graph on a
+The `rosbridge` service (enabled in the hardware and simulation profiles) exposes the ROS 2 graph on a
 WebSocket port so that external applications can interact with the boat without
 running ROS 2 natively.  It is configured to use a 5 s default timeout for
 service calls and to handle service and action requests in background threads so

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,14 @@
 # DDBoat ROS 2 – docker‑compose
 # ---------------------------
 # PROFILES
-#   • hw  – run against the real Raspberry Pi hardware
-#   • sim – full software emulation for laptops/CI
+#   • hw       – run against the real Raspberry Pi hardware
+#   • sim      – full software emulation for laptops/CI
+#   • hw_extra – run individual drivers one per container
 #
 # HARDWARE MODE SERVICES (profile: hw)
 #   ddboat_all      – start **all** drivers in one container (default workflow)
+#
+# INDIVIDUAL DRIVER CONTAINERS (profile: hw_extra)
 #   gps_node        – GNSS only
 #   arduino_node    – motor controller only
 #   encoders_node   – propeller encoders only
@@ -67,7 +70,7 @@ services:
     devices:
       - ${GPS_DEV:-/dev/ttyGPS0}:/dev/ttyGPS0
     command: ros2 run ros2_ddboat gps_node
-    profiles: ["hw"]
+    profiles: ["hw_extra"]
 
   arduino_node:
     <<: *ddboat_base
@@ -75,7 +78,7 @@ services:
     devices:
       - ${ARDUINO_DEV:-/dev/ttyV0}:/dev/ttyV0
     command: ros2 run ros2_ddboat arduino_node
-    profiles: ["hw"]
+    profiles: ["hw_extra"]
 
   encoders_node:
     <<: *ddboat_base
@@ -83,7 +86,7 @@ services:
     devices:
       - ${ENC_DEV:-/dev/ttyENC0}:/dev/ttyENC0
     command: ros2 run ros2_ddboat encoders_node
-    profiles: ["hw"]
+    profiles: ["hw_extra"]
 
   imu_node:
     <<: *ddboat_base
@@ -91,7 +94,7 @@ services:
     devices:
       - /dev/i2c-1:/dev/i2c-1
     command: ros2 run ros2_ddboat imu_node
-    profiles: ["hw"]
+    profiles: ["hw_extra"]
 
   temperature_node:
     <<: *ddboat_base
@@ -99,7 +102,7 @@ services:
     devices:
       - /dev/i2c-1:/dev/i2c-1
     command: ros2 run ros2_ddboat temperature_node
-    profiles: ["hw"]
+    profiles: ["hw_extra"]
 
   radio_node:
     <<: *ddboat_base
@@ -107,7 +110,7 @@ services:
     devices:
       - ${LORA_DEV:-/dev/ttyLORA1}:/dev/ttyLORA1
     command: ros2 run ros2_ddboat radio_node
-    profiles: ["hw"]
+    profiles: ["hw_extra"]
 
   # --------------------------------------------------
   # FULL STACK – SOFTWARE‑ONLY EMULATION
@@ -151,4 +154,4 @@ services:
                  -p default_call_service_timeout:=5.0 \
                  -p call_services_in_new_thread:=true \
                  -p send_action_goals_in_new_thread:=true'
-    depends_on: [ddboat_sim]
+    profiles: ["hw", "sim"]


### PR DESCRIPTION
## Summary
- add a dedicated `hw_extra` profile for individual driver containers
- make `rosbridge` available in hardware and simulation modes
- document the new behaviour in README

## Testing
- `pip install roslibpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ef159b3948328929f5a170e21b613