### PR TITLE
Fix encoder emulator blocking

### DIFF
--- a/ros2_ddboat/scripts/emulate_devices.py
+++ b/ros2_ddboat/scripts/emulate_devices.py
@@ -24,6 +24,7 @@ class Device:
     def __init__(self, path: str):
         master, slave = pty.openpty()
         self.master = master
+        os.set_blocking(self.master, False)
         self.slave_name = os.ttyname(slave)
         self.path = path
         if os.geteuid() == 0:
@@ -40,7 +41,10 @@ class Device:
     def write(self, data: bytes | str) -> None:
         if isinstance(data, str):
             data = data.encode()
-        os.write(self.master, data)
+        try:
+            os.write(self.master, data)
+        except OSError:
+            pass
 
 
 def gps_line() -> str:


### PR DESCRIPTION
## Summary
- ensure the emulator's master PTY is nonblocking
- ignore I/O errors when the master isn't ready

## Testing
- `pip install roslibpy`
- `pytest -q` *(no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_686f037f5ee08328a84ae1d24e811c33